### PR TITLE
Fix :  Total HT wasn't visible on list if author column is displayed

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,5 +2,6 @@
 
 
 ## 1.0
+- FIX : Total HT wasn't visible on list if author column is displayed - *02/02/2024* - 1.0.2
 - FIX : Remove useless fetchCommonLine  - *17/02/2023* - 1.0.1
 

--- a/core/modules/modExpedAmounts.class.php
+++ b/core/modules/modExpedAmounts.class.php
@@ -306,7 +306,7 @@ class modExpedAmounts extends DolibarrModules
 		// Create extrafields during init
 		include_once DOL_DOCUMENT_ROOT.'/core/class/extrafields.class.php';
 		$extrafields = new ExtraFields($this->db);
-		$result1=$extrafields->addExtraField('total_ht', "TotalHT", 'price', 1,  '24,8', 'expedition', 0, 0, '', '', 0, '$conf->expedamounts->enabled && $user->rights->expedamounts->read', '($conf->expedamounts->enabled && $user->rights->expedamounts->read ? 5 : 0)', '', '', 0, 'expedamounts@expedamounts', '$conf->expedamounts->enabled', 1);
+		$result1=$extrafields->addExtraField('total_ht', "TotalHT", 'price', 1,  '24,8', 'expedition', 0, 0, '', '', 0, 'global $user; $conf->expedamounts->enabled && $user->rights->expedamounts->read', 'global $user; ($conf->expedamounts->enabled && $user->rights->expedamounts->read ? 5 : 0)', '', '', 0, 'expedamounts@expedamounts', '$conf->expedamounts->enabled', 1);
 		$result2=$extrafields->addExtraField('shippingline_total_ht', "shippingline total ht", 'double', 1, '24,8', 'expeditiondet', 0, 0, '', '', 0, 1, 0, '', '', 0, 'expedamounts@expedamounts', '$conf->expedamounts->enabled');
 
 

--- a/core/modules/modExpedAmounts.class.php
+++ b/core/modules/modExpedAmounts.class.php
@@ -72,7 +72,7 @@ class modExpedAmounts extends DolibarrModules
 		$this->editor_url = 'https://www.atm-consulting.fr/';
 
 		// Possible values for version are: 'development', 'experimental', 'dolibarr', 'dolibarr_deprecated' or a version string like 'x.y.z'
-		$this->version = '1.0.1';
+		$this->version = '1.0.2';
 		// Url to the file with your last numberversion of this module
 		//$this->url_last_version = 'http://www.example.com/versionmodule.txt';
 


### PR DESCRIPTION
Hello,
I'm currently on dolibarr V14

when column Author is displayed the Total HT is not visible it's caused by this on expedition/list.php:952

![image](https://github.com/ATM-Consulting/dolibarr_module_expedamounts/assets/85104766/47e1c83c-13a6-4391-92c8-96b4095f15e0)

the $user is re defined here so check of the right in the extrafield cannot work.

I just added $user from the globals.

Before :

<img width="423" alt="image" src="https://github.com/ATM-Consulting/dolibarr_module_expedamounts/assets/85104766/21be967e-b510-41c1-984a-0b9dbb275de7">

After :
<img width="395" alt="image" src="https://github.com/ATM-Consulting/dolibarr_module_expedamounts/assets/85104766/ea0bd2ac-277b-4555-840f-b495ae695579">
